### PR TITLE
Fix pagination bounds check

### DIFF
--- a/apps/server/src/lib/pagination.ts
+++ b/apps/server/src/lib/pagination.ts
@@ -50,9 +50,9 @@ export const paginationOutput = <T>(
   const prevPage = currentPage > 1 ? currentPage - 1 : null;
   const nextPage = currentPage < lastPage ? currentPage + 1 : null;
 
-  if (page > lastPage) {
+  if (currentPage > lastPage && lastPage > 0) {
     throw new ORPCError("NOT_FOUND", {
-      message: `Page ${page} not found. Last page is ${lastPage}`,
+      message: `Page ${currentPage} not found. Last page is ${lastPage}`,
     });
   }
 


### PR DESCRIPTION
## Summary
- avoid 404 when paginating empty data sets
- validate page bounds using sanitized currentPage

## Testing
- `pnpm check`
- `pnpm check-types`


------
https://chatgpt.com/codex/tasks/task_e_689ab5cf921c832e9eced76a8c30840e